### PR TITLE
updated .gitignore and added popupwindow with notification where screenshot is stored #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ Thumbs.db
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+
+memory.json
+settings.json

--- a/screencap.py
+++ b/screencap.py
@@ -38,6 +38,14 @@ def qt_warnings():
     environ["QT_SCREEN_SCALE_FACTORS"] = "1"
     environ["QT_SCALE_FACTOR"] = "1"
 
+def showDialog():
+    msgWindow = QMessageBox()
+    msgWindow.setIcon(QMessageBox.Information)
+    msgWindow.setText("Screenshot is saved in " + config['image']['path'])
+    msgWindow.setWindowTitle("ScreenCap")  
+    msgWindow.exec_()
+    msgWindow.showNormal()
+
 class Ui_mainWindow(object):
     def setupUi(self, mainWindow):
         mainWindow.setObjectName("mainWindow")
@@ -139,22 +147,25 @@ class Ui_mainWindow(object):
             self.save_config()
 
     def clicked_folder(self):
-        screenshot_path = QtWidgets.QFileDialog.getExistingDirectory(None, 'Select Folder')
-        if config['image']['path'] != screenshot_path:
-            config['image']['path'] = screenshot_path
-            self.save_config()
+        screenshot_path = QtWidgets.QFileDialog.getExistingDirectory(None, 'Select Folder' , config['image']['path'])
+        if screenshot_path:
+            if config['image']['path'] != screenshot_path:
+                config['image']['path'] = screenshot_path
+                self.save_config()
             
     def clicked_sceenshot(self):
         if (config['image']['path']) is None:
             self.clicked_folder()
-        now = datetime.now()
-        timeNow = now.strftime("%d-%m-%Y %H.%M.%S")
-        path = os.path.join(config['image']['path'], config['image']['name'] + timeNow + config['image']["extension"])
-        mainWindow.showMinimized()
-        time.sleep(0.5)
-        screenshot = ImageGrab.grab()
-        screenshot.save(path)
-        mainWindow.showNormal()
+        if config['image']['path']:
+            now = datetime.now()
+            timeNow = now.strftime("%d-%m-%Y %H.%M.%S")
+            path = os.path.join(config['image']['path'], config['image']['name'] + timeNow + config['image']["extension"])
+            mainWindow.close()
+            time.sleep(0.5)
+            screenshot = ImageGrab.grab()
+            screenshot.save(path)
+            showDialog()
+            mainWindow.showNormal()
 
     def save_config(self):
         with open('memory.json', 'w') as f:

--- a/screencap.py
+++ b/screencap.py
@@ -38,7 +38,7 @@ def qt_warnings():
     environ["QT_SCREEN_SCALE_FACTORS"] = "1"
     environ["QT_SCALE_FACTOR"] = "1"
 
-def showDialog():
+def show_dialog():
     msgWindow = QMessageBox()
     msgWindow.setIcon(QMessageBox.Information)
     msgWindow.setText("Screenshot is saved in " + config['image']['path'])
@@ -164,7 +164,7 @@ class Ui_mainWindow(object):
             time.sleep(0.5)
             screenshot = ImageGrab.grab()
             screenshot.save(path)
-            showDialog()
+            show_dialog()
             mainWindow.showNormal()
 
     def save_config(self):


### PR DESCRIPTION
Updated .gitignore #19 file, now git ignores memory.json
#20 Once you take a screenshot, the program will display a pop-up window with information about where the screenshot is stored
also, if you open the folder menu in the upper menu, the current folder is displayed

also fixed a problem, when you click on the folder menu you do not select any folder and simply close the window, the settings now remain at the previous one. Changes made on lines 151 and 159.
Before changes function returns None